### PR TITLE
[WIP] Updates for deploying new angular 6 encompass application

### DIFF
--- a/manticore_django/fabfile/deploy.py
+++ b/manticore_django/fabfile/deploy.py
@@ -766,7 +766,7 @@ def installapp():
     sudo("dpkg -i rabbitmq-server_2.8.4-1_all.deb")
 
     sudo("easy_install pip")
-    sudo("pip install virtualenv --no-use-wheel")
+    sudo("pip install virtualenv --index-url https://pypi.org/simple")
     apt(" ".join(env.apt_requirements))
 
 @task
@@ -837,6 +837,24 @@ def upgrade_nodejs():
     sudo("npm cache clean -f")
     sudo("npm install -g n")
     sudo("n 7.6.0")
+
+@task
+@parallel
+@roles('application', 'cron')
+def install_nvm_lts():
+    """
+        Installs nvm --lts
+    """
+    sudo("nvm install --lts")
+
+@task
+@parallel
+@roles('application', 'cron')
+def install_angular_cli():
+    """
+        Installs Angular CLI
+    """
+    sudo("npm install -g @angular/cli")
 
 @task
 @parallel
@@ -1365,10 +1383,11 @@ def deployapp2(collect_static=True):
             if env.bower:
                 run("bower install --allow-root")
 
-            with cd("meterclient/static"):
+            with cd("meterclient/meterclient-ng"):
                 run("npm install")
-                run("tsc")
-                run("npm run build:prod")
+                run("nvm use --lts")
+                run("ng build app-tsc")
+                run("ng build pdf-app-tsc")
 
             manage("collectstatic -v 0 --noinput", True)
 

--- a/manticore_django/fabfile/deploy.py
+++ b/manticore_django/fabfile/deploy.py
@@ -1379,15 +1379,17 @@ def deployapp2(collect_static=True):
         run("git submodule sync")
         run("git submodule update")
         if env.mode != "vagrant" and collect_static:
+            # Note: 2/19/2019 - [Alex] Doesn't look like we're using bower?
+            # Commenting out since the build started breaking here for some reason
             # If we're using bower, make sure we install our javascript files before collecting static and compressing
-            if env.bower:
-                run("bower install --allow-root")
+            # if env.bower:
+            #     run("bower install --allow-root")
 
             with cd("meterclient/meterclient-ng"):
                 run("npm install")
-                run("nvm use --lts")
-                run("ng build app-tsc")
-                run("ng build pdf-app-tsc")
+                run("nvm use --lts")  # Note: Do we even need "nvm use lts?
+                run("npm run build:prod:web")
+                run("npm run build:prod:pdf")
 
             manage("collectstatic -v 0 --noinput", True)
 


### PR DESCRIPTION
@rmutter 
Not sure if I did this right, but here are updates so that we can deploy the new version of Encompass.
Mostly confused about how the setup code is run, and how the script knows what to run vs what to ignore (as in, how does it know to run the two new commands, but to skip installing electroshot etc)

Here's a screenshot of what my file structure looks like in `meterclient` if you want to check that the paths are correct. You should also be able to look at the `develop` branch of Encompass.
<img width="263" alt="screen shot 2019-02-10 at 21 30 11" src="https://user-images.githubusercontent.com/4390242/52533706-13ec6e80-2d7b-11e9-9c42-5ff1b42b385c.png">

One thing I'm curious about is that we needed to delete the `node_modules` folder before reinstalling everything. Does that happen anywhere in the deploy script? (I didn't see it, but I might have missed it) If not, is it something I should add, or just do manually? I think in the past when deploying the A4 upgrade I may have had to do it manually.


So, I assume there's still work to be done here and that I'm missing some way to say "run X commands" or "skip Y commands", and that it has to do with the `@roles`.

Also, is anything in the `nginx config` going to need updating? Particularly looking at this line:
```

    # Cache angular html files for only an hour, this helps with pushing new updates
    location /static/app_tsc/components/ {
        root            %(proj_path)s;
        expires         1h;
        add_header      Cache-Control public;
    }
```